### PR TITLE
bootloader_config.h: Don't redefine BL_TARGET_FLASH

### DIFF
--- a/targets/MK22F51212/src/bootloader_config.h
+++ b/targets/MK22F51212/src/bootloader_config.h
@@ -58,7 +58,9 @@
 #if !defined(BL_CONFIG_USB_MSC)
 #define BL_CONFIG_USB_MSC (0)
 #endif
+#if !defined(BL_TARGET_FLASH)
 #define BL_TARGET_FLASH (1)
+#endif
 //@}
 
 #if !defined(BL_TARGET_FLASH) && !defined(BL_TARGET_RAM)


### PR DESCRIPTION
`BL_TARGET_FLASH` can be specified on the command-line too, do not redefine it unconditionally, but guard it with an ifdef. This should eliminate the warnings seen during compilation, and as such, fixes #1.

Note that I have not compiled the source, so can't verify that this indeed fixes he warnings. But based on the output pasted into the issue, it should. This is the file being included, and I saw no other warnings in there. Your mileage may vary, though.